### PR TITLE
Generate docs.rs docs for all crate features

### DIFF
--- a/derive_fuzztest/Cargo.toml
+++ b/derive_fuzztest/Cargo.toml
@@ -35,3 +35,7 @@ workspace = true
 [dev-dependencies]
 anyhow = "1.0.86"
 xshell = "0.2.6"
+
+[package.metadata.docs.rs]
+# Generate docs for all features.
+all-features = true


### PR DESCRIPTION
Adds metadata as specified at <https://docs.rs/about/metadata> to enable all features when generating docs.